### PR TITLE
Updated to use generation (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ memcached-operator is still under active development and has not been extensivel
 
 ## Prerequisites
 
-* Version >= 1.8 of Kubernetes.
+* Version >= 1.10 of Kubernetes.
 
-memcached-operator relies on [garbage collection](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/) support for custom resources which is in Kubernetes 1.8+
+memcached-operator relies on [subresources for CRDs](https://github.com/kubernetes/kubernetes/pull/55168) which is in 1.10+
 
 ## Quickstart
 

--- a/internal/apis/ianlewis.org/v1alpha1/types.go
+++ b/internal/apis/ianlewis.org/v1alpha1/types.go
@@ -18,8 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"github.com/ianlewis/memcached-operator/internal/util/hash"
 )
 
 const (
@@ -53,11 +51,6 @@ type MemcachedProxySpec struct {
 func (s *MemcachedProxySpec) ApplyDefaults(p *MemcachedProxy) {
 	s.McRouter.ApplyDefaults(p)
 	s.Rules.ApplyDefaults(p)
-}
-
-// GetHash gets a hash of the MemcachedProxySpec
-func (s *MemcachedProxySpec) GetHash() (string, error) {
-	return hash.GetHash(s)
 }
 
 type McRouterSpec struct {
@@ -125,14 +118,8 @@ func (s *ServiceSpec) ApplyDefaults(p *MemcachedProxy) {
 
 // MemcachedProxyStatus is the most recently observed status of the cluster
 type MemcachedProxyStatus struct {
-	// The generation observed by the MemcachedProxy controller. Not used currently as generation is not updated for CRDs.
-	// Proper support for CRDs is being worked on.
-	// See: https://github.com/kubernetes/community/pull/913
-	// TODO: implement ObservedGeneration
-	// ObservedGeneration int64 `json:"observedGeneration,omitempty"`
-	// This is a workaround for the fact that Generation and sub-resources are not fully supported for CRDs yet.
-	// We assume that end users will not update the status object and especially this field.
-	ObservedSpecHash string `json:"observedSpecHash,omitempty"`
+	// The generation observed by the MemcachedProxy controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// TODO: updated replicas in status?
 	// Replicas int32 `json:"replicas,omitempty"`
 

--- a/internal/controller/proxy/controller.go
+++ b/internal/controller/proxy/controller.go
@@ -208,10 +208,6 @@ func (c *Controller) syncHandler(key string) error {
 }
 
 func (c *Controller) updateStatus(p *v1alpha1.MemcachedProxy) error {
-	hash, err := p.Spec.GetHash()
-	if err != nil {
-		return fmt.Errorf("failed to hash spec for %q: %v", p.Namespace+"/"+p.Name, err)
-	}
-	p.Status.ObservedSpecHash = hash
+	p.Status.ObservedGeneration = p.Generation
 	return nil
 }

--- a/internal/controller/proxy/controller_test.go
+++ b/internal/controller/proxy/controller_test.go
@@ -100,8 +100,8 @@ func TestSync(t *testing.T) {
 
 		f.ExpectCRDClientActions([]test.ExpectedAction{
 			{
-				core.NewUpdateAction(schema.GroupVersionResource{Resource: "memcachedproxies"}, p.Namespace, p),
-				func(t *testing.T, action core.Action) {
+				Action: core.NewUpdateAction(schema.GroupVersionResource{Resource: "memcachedproxies"}, p.Namespace, p),
+				F: func(t *testing.T, action core.Action) {
 					a := action.(core.UpdateAction)
 					pNew := a.GetObject().(*v1alpha1.MemcachedProxy)
 
@@ -109,7 +109,7 @@ func TestSync(t *testing.T) {
 					assert.Equal(t, pNew.Spec.Rules.Type, v1alpha1.ShardedRuleType, "rules type must be equal")
 
 					// Check that the observed hash was set
-					assert.NotEmpty(t, pNew.Status.ObservedSpecHash, "observed spec hash must be set")
+					assert.Equal(t, pNew.Status.ObservedGeneration, p.Generation, "observed spec hash must be set")
 				},
 			},
 		})

--- a/internal/controller/proxyconfigmap/config_test.go
+++ b/internal/controller/proxyconfigmap/config_test.go
@@ -168,6 +168,7 @@ func TestPoolForService(t *testing.T) {
 				Name:        "hoge",
 				Namespace:   metav1.NamespaceDefault,
 				Annotations: make(map[string]string),
+				Generation:  1,
 			},
 			Spec: v1alpha1.MemcachedProxySpec{
 				Rules: v1alpha1.RuleSpec{
@@ -179,11 +180,9 @@ func TestPoolForService(t *testing.T) {
 				},
 			},
 		}
+		p.Status.ObservedGeneration = p.Generation
 
 		p.ApplyDefaults()
-
-		hash, _ := p.Spec.GetHash()
-		p.Status.ObservedSpecHash = hash
 
 		// Create the service "fuga". This service has two ports.
 		// Port 1000 maps to 11211 on target pods.

--- a/internal/controller/proxyconfigmap/controller.go
+++ b/internal/controller/proxyconfigmap/controller.go
@@ -292,13 +292,9 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// Check if the current version has been observed by the proxy controller
-	hash, err := p.Spec.GetHash()
-	if err != nil {
-		return fmt.Errorf("failed to get hash for %q: %v", key, err)
-	}
-	if hash != p.Status.ObservedSpecHash {
+	if p.Generation != p.Status.ObservedGeneration {
 		// Requeue
-		c.l.Info.V(5).Printf("memcached proxy %q status not updated. requeueing", key)
+		c.l.Info.V(5).Printf("Waiting for proxy controller to update %q. requeueing...", key)
 		c.queue.AddRateLimited(key)
 		return nil
 	}

--- a/internal/controller/proxydeployment/controller.go
+++ b/internal/controller/proxydeployment/controller.go
@@ -235,13 +235,9 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// Check if the current version has been observed by the proxy controller
-	hash, err := p.Spec.GetHash()
-	if err != nil {
-		return fmt.Errorf("failed to get hash for %q: %v", key, err)
-	}
-	if hash != p.Status.ObservedSpecHash {
+	if p.Generation != p.Status.ObservedGeneration {
 		// Requeue
-		c.l.Info.V(5).Printf("memcached proxy %q status not updated. requeueing", key)
+		c.l.Info.V(5).Printf("Waiting for proxy controller to update %q. requeueing...", key)
 		c.queue.AddRateLimited(key)
 		return nil
 	}

--- a/internal/controller/proxyservice/controller.go
+++ b/internal/controller/proxyservice/controller.go
@@ -240,13 +240,9 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// Check if the current version has been observed by the proxy controller
-	hash, err := p.Spec.GetHash()
-	if err != nil {
-		return fmt.Errorf("failed to get hash for %q: %v", key, err)
-	}
-	if hash != p.Status.ObservedSpecHash {
+	if p.Generation != p.Status.ObservedGeneration {
 		// Requeue
-		c.l.Info.V(5).Printf("memcached proxy %q status not updated. requeueing", key)
+		c.l.Info.V(5).Printf("Waiting for proxy controller to update %q. requeueing...", key)
 		c.queue.AddRateLimited(key)
 		return nil
 	}

--- a/internal/test/memcachedproxy.go
+++ b/internal/test/memcachedproxy.go
@@ -52,16 +52,15 @@ func NewMemcachedProxy(name string, rules v1alpha1.RuleSpec) *v1alpha1.Memcached
 			Name:        name,
 			Namespace:   metav1.NamespaceDefault,
 			Annotations: make(map[string]string),
+			Generation:  1,
 		},
 		Spec: v1alpha1.MemcachedProxySpec{
 			Rules: rules,
 		},
 	}
+	p.Status.ObservedGeneration = p.Generation
 
 	p.ApplyDefaults()
-
-	hash, _ := p.Spec.GetHash()
-	p.Status.ObservedSpecHash = hash
 
 	return p
 }


### PR DESCRIPTION
Uses Kubernetes generation to check that the proxy controller has seen changes to the MemcachedProxy and updated the status. The observed generation in saved to the status as observedGeneration.