### PR TITLE
Updating Helm API Versions for Deployment/RBAC, and adding required selector for Deployment

### DIFF
--- a/charts/memcached-operator/templates/deployment.yaml
+++ b/charts/memcached-operator/templates/deployment.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -23,6 +23,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/charts/memcached-operator/templates/rbac.yaml
+++ b/charts/memcached-operator/templates/rbac.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "fullname" . }}
@@ -32,7 +32,7 @@ rules:
   resources: ["replicasets", "endpoints"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "fullname" . }}


### PR DESCRIPTION
Resolving unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"
Resolving error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec